### PR TITLE
Improve "unpublished" logic to handle blank queries and document requests

### DIFF
--- a/lib/es-proxy.js
+++ b/lib/es-proxy.js
@@ -41,29 +41,37 @@ class ESProxy {
     const beRestricted = { term: { visibility: 'restricted' } }
     const beUnpublished = { term: { published: false } }
 
+    var filteredQuery;
     if (this.isNotLoggedIn()) {
-      return {
+      filteredQuery = {
         bool: {
           must: [matchTheQuery, beOpen],
           must_not: [beUnpublished]
         }
       }
     } else {
-      return {
+      filteredQuery = {
         bool: {
           must: [matchTheQuery],
           must_not: [beRestricted, beUnpublished],
         }
       }
     }
+    return filteredQuery;
   }
 
   wrapQuery(payload) {
     let wrapFunction = (doc) => {
-      doc.query = this.filter(doc.query);
+      doc.query = this.filter(doc.query || { match_all: {} });
       return doc;
     }
-    return payload.map ? payload.map(wrapFunction) : payload;
+    if (payload.map) {
+      return payload.map(wrapFunction);
+    } else if (isObject(payload)) {
+      return wrapFunction(payload);
+    } else {
+      return payload;
+    }
   }
 
   async awsFetch(request) {
@@ -132,9 +140,20 @@ class ESProxy {
         if (/\/json(?:;.+)$/.test(response.headers['content-type'])) {
           var doc = JSON.parse(response.body);
           var deauthorize = false;
-          if (doc._type == '_doc' && doc._source.visibility != 'open') {
-            deauthorize = this.isNotLoggedIn() || doc._source.visibility == 'restricted';
+
+          // Explicitly unpublished docs are visible to no one
+          // Otherwise:
+          //   * `open` docs are visible to all
+          //   * `restricted` docs are visible to no one
+          //   * `authenticated` docs are visible to logged in users
+          if (doc._type == '_doc') {
+            if (doc._source.published == false) {
+              deauthorize = true;
+            } else if (doc._source.visibility != 'open') {
+              deauthorize = this.isNotLoggedIn() || doc._source.visibility == 'restricted';
+            }
           }
+
           if (deauthorize) {
             response.statusCode = 403;
             response.body = '{ type: "error", message: "Unauthorized" }';


### PR DESCRIPTION
Per @kdid's observation, single-document (`/search/INDEX/_doc/ID`) requests were not being checked for published/unpublished status. In fixing the issue, I noticed an edge case where a blank search was not properly excluding restricted and/or unpublished results. This PR fixes both cases.