### PR TITLE
Fix cookie auth without breaking header or bearer auth

### DIFF
--- a/lib/auth-utils.js
+++ b/lib/auth-utils.js
@@ -7,15 +7,25 @@ function isEmpty(val) {
   return val === null || val === undefined || val === "";
 }
 
+function extractToken(req) {
+  return req.get(req.app.get("api-token-header"));
+}
+
+function extractAuthHeader(req) {
+  let authHeader = req.get("Authorization");
+  if (!isEmpty(authHeader) && authHeader.match(/^Bearer /)) {
+    return authHeader.replace(/^Bearer /, "");
+  }
+  return null;
+}
+
+function extractApiCookie(req) {
+  return req.cookies[req.app.get("api-token-cookie")];
+}
+
 function user() {
   return (req, res, next) => {
-    let token = req.get(req.app.get("api-token-header"));
-    if (isEmpty(token)) {
-      let auth_header = req.get("Authorization");
-      if (!isEmpty(auth_header) && auth_header.match(/^Bearer /)) {
-        token = req.get("Authorization").replace(/^Bearer /, "");
-      }
-    }
+    let token = extractToken(req) || extractAuthHeader(req) || extractApiCookie(req);
     let secret = req.app.get("api-token-secret");
     if (token != null) {
       try {


### PR DESCRIPTION
`elastic-proxy` should look for the encrypted JSON auth token in the following places, in order:

1. `X-API-Token` header (ex: `X-API-Token: TOKEN`)
2. `Authorization` header (ex: `Authorization: Bearer TOKEN`)
3. `dcApiToken` cookie (ex: `Cookie: dcApiToken=TOKEN`)

The first two were already working, but this PR makes the code more readable and adds support for the third method.