### PR TITLE
Fix a small scroll query bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,9 @@ jobs:
           paths:
             - ~/elastic-proxy/node_modules
       - run:
+          name: Wait for Elasticsearch
+          command: timeout 60 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:9200)" != "200" ]]; do sleep 5; done' || false
+      - run:
           name: Load fixtures
           command: 'curl --data-binary @"test/fixtures/docs.njson" -H "Content-Type: application/x-ndjson" http://localhost:9200/_bulk'
       - run:

--- a/lib/es-proxy.js
+++ b/lib/es-proxy.js
@@ -74,6 +74,7 @@ class ESProxy {
 
   wrapQuery(payload) {
     let wrapFunction = (doc) => {
+      if (doc.scroll_id) { return doc; }
       doc.query = this.filter(doc.query || { match_all: {} });
       return doc;
     }

--- a/test/scroll_test.js
+++ b/test/scroll_test.js
@@ -1,0 +1,32 @@
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const expect = chai.expect;
+chai.use(chaiHttp);
+const jwt = require('jsonwebtoken');
+const server = 'http://localhost:3334/'
+const query = {query:{bool:{must:[{bool:{must:[{match:{"model.name":"Image"}}]}}]}}}
+
+const token = jwt.sign('testuser@northwestern.edu', process.env.API_TOKEN_SECRET)
+
+describe('Scroll', () => {
+  it('should allow scrolling', done => {
+    chai.request(server)
+      .post('search/scalar_visibility,object_visibility/_search?scroll=1m')
+      .set("Content-Type", "application/json")
+      .send(query)
+      .end((err, res) => {
+        expect(err).to.be.null;
+        expect(res).to.have.status(200);
+        let scrollId = res.body._scroll_id;
+        chai.request(server)
+          .post('search/_search/scroll')
+          .set("Content-Type", "application/json")
+          .send({scroll: '1m', scroll_id: scrollId})
+          .end((err, res) => {
+            expect(err).to.be.null;
+            expect(res).to.have.status(200);
+            done();
+          });
+      });
+  });
+});


### PR DESCRIPTION
While testing the recent changes to the proxy on staging, @davidschober discovered a regression bug related to followup scroll queries. This PR fixes it by not attempting to wrap scroll requests.